### PR TITLE
API Test and ReadMe updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Instructions for Running locally -
 For ReadingRainbowAPI and ReadingRainbowAPI.Tests
     .NetCore SDK 3.1 needs to be installed
     Install Neo4jClient : dotnet add package Neo4jClient
+        To run this project you will need Neo4jClient version 4.0.0 or greater: https://www.nuget.org/packages/Neo4jClient
     Install Neo4j.Driver : dotnet add package Neo4j.Driver
 
 For ReadingRainbowAPI.Tests

--- a/ReadingRainbowAPI.Tests/ControllerTests/BooksControllerTests.cs
+++ b/ReadingRainbowAPI.Tests/ControllerTests/BooksControllerTests.cs
@@ -75,8 +75,11 @@ namespace ReadingRainbowAPI.ControllerTests
             await _personRepository.AddOrUpdatePersonAsync(person1);
             await _personRepository.AddOrUpdatePersonAsync(person2);
 
-            await _bookRepository.CreateInLibraryRelationshipAsync(book1, person1, new InLibrary());
-            await _bookRepository.CreateInLibraryRelationshipAsync(book1, person2, new InLibrary());
+            var inLibrary1 = new InLibrary();
+            var inLibrary2 = new InLibrary();
+
+            await _bookRepository.CreateInLibraryRelationshipAsync(book1, person1, inLibrary1);
+            await _bookRepository.CreateInLibraryRelationshipAsync(book1, person2, inLibrary2);
 
             // Act
 
@@ -86,6 +89,14 @@ namespace ReadingRainbowAPI.ControllerTests
             // Assert
             Assert.True(okResult != null);
             Assert.Equal(200, okResult.StatusCode);
+
+            // Clean up
+            await _bookRepository.DeleteInLibraryRelationshipAsync(book1, person1, inLibrary1);
+            await _bookRepository.DeleteInLibraryRelationshipAsync(book1, person2, inLibrary2);
+            await _bookRepository.DeleteBookAsync(book1);
+            await _personRepository.DeletePersonAsync(person1);
+            await _personRepository.DeletePersonAsync(person2);
+            
         }
 
         [Fact]
@@ -101,6 +112,9 @@ namespace ReadingRainbowAPI.ControllerTests
             // Assert
             Assert.True(returnedBook != null);
             Assert.True(returnedBook.Title == newBook.Title);
+
+            // Clean up
+            await _bookRepository.DeleteBookAsync(newBook);
         }
 
         [Fact]
@@ -117,6 +131,9 @@ namespace ReadingRainbowAPI.ControllerTests
             // Assert
             Assert.True(okResult != null);
             Assert.Equal(200, okResult.StatusCode);
+
+                        // Clean up
+            await _bookRepository.DeleteBookAsync(newBook);
         }
 
         [Fact]
@@ -134,6 +151,10 @@ namespace ReadingRainbowAPI.ControllerTests
             // Assert
             Assert.True(okResult != null);
             Assert.Equal(200, okResult.StatusCode);
+
+            // Clean up
+            await _bookRepository.DeleteBookAsync(book1);
+            await _bookRepository.DeleteBookAsync(book2);
            
         }
 

--- a/ReadingRainbowAPI.Tests/ControllerTests/PeopleControllerTests.cs
+++ b/ReadingRainbowAPI.Tests/ControllerTests/PeopleControllerTests.cs
@@ -75,8 +75,11 @@ namespace ReadingRainbowAPI.ControllerTests
             await _bookRepository.AddOrUpdateAsync(book2);
             await _personRepository.AddOrUpdatePersonAsync(person1);
 
-            await _bookRepository.CreateInLibraryRelationshipAsync(book1, person1, new InLibrary());
-            await _bookRepository.CreateInLibraryRelationshipAsync(book2, person1, new InLibrary());
+            var inLibrary1 = new InLibrary();
+            var inLibrary2 = new InLibrary();
+
+            await _bookRepository.CreateInLibraryRelationshipAsync(book1, person1, inLibrary1);
+            await _bookRepository.CreateInLibraryRelationshipAsync(book2, person1, inLibrary2);
 
             // Act
 
@@ -86,6 +89,13 @@ namespace ReadingRainbowAPI.ControllerTests
             // Assert
             Assert.True(okResult != null);
             Assert.Equal(200, okResult.StatusCode);
+
+             // Clean up
+            await _bookRepository.DeleteInLibraryRelationshipAsync(book1, person1, inLibrary1);
+            await _bookRepository.DeleteInLibraryRelationshipAsync(book2, person1, inLibrary2);
+            await _bookRepository.DeleteBookAsync(book1);
+            await _bookRepository.DeleteBookAsync(book2);
+            await _personRepository.DeletePersonAsync(person1);
         }
 
         [Fact]
@@ -101,6 +111,9 @@ namespace ReadingRainbowAPI.ControllerTests
             // Assert
             Assert.True(returnedPerson != null);
             Assert.True(returnedPerson.Profile == newPerson.Profile);
+
+            // Clean up
+            await _personRepository.DeletePersonAsync(newPerson);
         }
 
         [Fact]
@@ -117,6 +130,9 @@ namespace ReadingRainbowAPI.ControllerTests
             // Assert
             Assert.True(okResult != null);
             Assert.Equal(200, okResult.StatusCode);
+
+            // Clean up
+            await _personRepository.DeletePersonAsync(newPerson);
         }
 
         [Fact]
@@ -134,6 +150,10 @@ namespace ReadingRainbowAPI.ControllerTests
             // Assert
             Assert.True(okResult != null);
             Assert.Equal(200, okResult.StatusCode);
+
+            // Clean up
+            await _personRepository.DeletePersonAsync(person1);
+            await _personRepository.DeletePersonAsync(person2);
            
         }
 

--- a/ReadingRainbowAPI.Tests/RepositoryTests/BookRepositoryTests.cs
+++ b/ReadingRainbowAPI.Tests/RepositoryTests/BookRepositoryTests.cs
@@ -57,8 +57,21 @@ namespace ReadingRainbowAPI.RepositoryTests
         [Fact]
         public async void GetBookAsync_Test()
         {
+            // Arrange
+            var book1 = CreateBook();
+            var book2 = CreateBook();
+            await _bookRepository.AddOrUpdateAsync(book1);
+            await _bookRepository.AddOrUpdateAsync(book2);
+
+            // Act
             var books = await _bookRepository.GetAllBooksAsync();
+
+            // Assert
             Assert.True(books != null);
+
+            // Clean up
+            await _bookRepository.DeleteBookAsync(book1);
+            await _bookRepository.DeleteBookAsync(book2);
         }
 
         [Fact]
@@ -74,6 +87,9 @@ namespace ReadingRainbowAPI.RepositoryTests
             // Assert
             Assert.True(returnedBook != null);
             Assert.True(returnedBook.Title == newBook.Title);
+
+            // Clean up
+            await _bookRepository.DeleteBookAsync(newBook);
         }
 
         [Fact]
@@ -96,6 +112,9 @@ namespace ReadingRainbowAPI.RepositoryTests
             // Assert
             Assert.True(returnedBook != null);
             Assert.True(returnedBook.Title == newBookTitle);
+
+            // Clean up
+            await _bookRepository.DeleteBookAsync(newBook);
         }
 
         [Fact]
@@ -112,6 +131,9 @@ namespace ReadingRainbowAPI.RepositoryTests
             // Assert
             Assert.True(returnedBookList.Count != 0);
             Assert.True(returnedBookList.Where(b=>b.Description.Contains(searchText)).ToList().Count == returnedBookList.Count);
+
+            // Clean up
+            await _bookRepository.DeleteBookAsync(newBook);
         }
 
         [Fact]
@@ -138,14 +160,21 @@ namespace ReadingRainbowAPI.RepositoryTests
 
             var newPerson = CreatePerson();
             await _personRepository.AddOrUpdatePersonAsync(newPerson);
+
+            var inLibrary = new Relationships.InLibrary();
             
             // Act
-            await _bookRepository.CreateInLibraryRelationshipAsync(newBook, newPerson, new Relationships.InLibrary());
-            var returnedPerson = (await _bookRepository.GetInLibraryPersonRelationshipAsync(newBook, new Relationships.InLibrary()))
+            await _bookRepository.CreateInLibraryRelationshipAsync(newBook, newPerson, inLibrary);
+            var returnedPerson = (await _bookRepository.GetInLibraryPersonRelationshipAsync(newBook, inLibrary))
                 .ToList().FirstOrDefault();
 
             // Assert
             Assert.True(newPerson.Name == returnedPerson.Name);
+
+            // Clean up
+            await _bookRepository.DeleteInLibraryRelationshipAsync(newBook, newPerson, inLibrary);
+            await _bookRepository.DeleteBookAsync(newBook);
+            await _personRepository.DeletePersonAsync(newPerson);
         }
     }
 }

--- a/ReadingRainbowAPI.Tests/RepositoryTests/PersonRepositoryTests.cs
+++ b/ReadingRainbowAPI.Tests/RepositoryTests/PersonRepositoryTests.cs
@@ -40,8 +40,17 @@ namespace ReadingRainbowAPI.RepositoryTests
         [Fact]
         public async void GetPeopleAsync_Test()
         {
+            var person1 = CreatePerson();
+            var person2 = CreatePerson();
+            await _personRepository.AddOrUpdatePersonAsync(person1);
+            await _personRepository.AddOrUpdatePersonAsync(person2);
+
             var people = await _personRepository.GetAllPeopleAsync();
             Assert.True(people != null);
+
+            // Clean up
+            await _personRepository.DeletePersonAsync(person1);
+            await _personRepository.DeletePersonAsync(person2);
         }
 
         [Fact]
@@ -57,6 +66,9 @@ namespace ReadingRainbowAPI.RepositoryTests
             // Assert
             Assert.True(returnedPerson != null);
             Assert.True(returnedPerson.Name == newPerson.Name);
+
+            // Clean up
+            await _personRepository.DeletePersonAsync(newPerson);
         }
 
         [Fact]
@@ -79,6 +91,9 @@ namespace ReadingRainbowAPI.RepositoryTests
             // Assert
             Assert.True(returnedPerson != null);
             Assert.True(returnedPerson.Profile == newPersonProfile);
+
+            // Clean up
+            await _personRepository.DeletePersonAsync(newPerson);
         }
 
         [Fact]
@@ -90,6 +105,9 @@ namespace ReadingRainbowAPI.RepositoryTests
             var returnedperson = await _personRepository.GetPersonAsync(newPerson.Name);
 
             Assert.True(newPerson.HashedPassword == returnedperson.HashedPassword);
+
+            // Clean up
+            await _personRepository.DeletePersonAsync(newPerson);
         }
 
     }


### PR DESCRIPTION
1. Updated Readme file to call out correct (minimum) revision of Neo4jClient
2. Updated API Tests to added Clean up functions to remove test data added for test. This is so that the database does not get full of test data when running the tests and the database is kept in a known state.